### PR TITLE
Display main as "Included Alt" in contacts

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -65,11 +65,17 @@ class Account extends Authenticatable
 
     /**
      * Get an accounts alts
+     * 
+     * @param $include_main bool
      *
      * @return mixed
      */
-    public function alts()
+    public function alts($include_main = false)
     {
-        return User::where('account_id', $this->id)->where('character_id', '!=', $this->main_user_id)->get();
+        if ($include_main) {
+            return User::where('account_id', $this->id)->get();
+        } else {
+            return User::where('account_id', $this->id)->where('character_id', '!=', $this->main_user_id)->get();
+        }
     }
 }

--- a/resources/views/parts/application/overview.blade.php
+++ b/resources/views/parts/application/overview.blade.php
@@ -301,7 +301,7 @@
                         @if($contact->getContactId() > 3000000 && $contact->getContactId() < 4000000)
                             <span class="badge badge-pill badge-primary">NPC</span>
                         @endif
-                        @if(sizeof(array_filter($account->alts()->toArray(), function ($e) use (&$contact) { return $e['character_id'] == $contact->getContactId(); })) > 0)
+                        @if(sizeof(array_filter($account->alts(true)->toArray(), function ($e) use (&$contact) { return $e['character_id'] == $contact->getContactId(); })) > 0)
                             <span class="badge badge-pill badge-success">Included Alt</span>
                         @endif
                         </div>


### PR DESCRIPTION
Minor fix to display an applicant's main character as an "Included Alt" when viewing contacts.