### PR TITLE
Move new EsiConnection into the try/catch so invalid tokens are correctly identified when using CORE_USE_ACCESS_TOKEN=true

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -52,9 +52,9 @@ class ApplicationController extends Controller
             return redirect('/')->with('error', 'Unauthorized');
 
         User::updateUsersOnApplicationLoad($application->account->main_user_id);
-        $esi = new EsiConnection($application->account->main_user_id);
 
         try {
+            $esi = new EsiConnection($application->account->main_user_id);
             $sp = $esi->getSkillpoints();
             $isk = $esi->getWalletBalance();
             $titles = $esi->getTitles();


### PR DESCRIPTION
When using `CORE_USE_ACCESS_TOKEN=true`, we fail in the `new EsiConnection` stage instead of on the later calls (e.g. `getSkillpoints` in `viewApplication` because neucore fails to refresh the token and returns an empty reponse.

Moving the construction into the try/catch prevents `viewApplication` from bombing out with a 500 entirely and allows us to correctly realize the token is invalid and render the invalid token page, allowing recruiters to view and close out applications where the main character has an invalid token.

Testing - when the main character's token is invalid:

<img width="807" height="336" alt="image" src="https://github.com/user-attachments/assets/622eb97f-5e04-47bc-9b84-595fceecafc3" />

Before this change, the entire page fails to load:

<img width="440" height="134" alt="image" src="https://github.com/user-attachments/assets/1700392f-647e-44b4-a60f-e92a9d71ffb0" />

After this change, the page correctly loads with the "invalid token" text:

<img width="729" height="409" alt="image" src="https://github.com/user-attachments/assets/d64eb55a-e86a-40ad-9272-d86dc2d52e92" />

I looked into adding a unit test but concluded it would be excessively difficult with the way the current tests are setup.