### PR TITLE
Indicate when items in a contract are requested instead of given

### DIFF
--- a/app/Connectors/EsiConnection.php
+++ b/app/Connectors/EsiConnection.php
@@ -1128,6 +1128,7 @@ class EsiConnection
                     'type' => null,
                     'quantity' => $item->getQuantity(),
                     'price' => null,
+                    'is_included' => $item->getIsIncluded(),
                 ];
             }
 

--- a/resources/views/parts/application/contracts.blade.php
+++ b/resources/views/parts/application/contracts.blade.php
@@ -46,7 +46,7 @@
                                 <tr>
                                     <td>
                                         <img src="https://image.eveonline.com/Type/{{ $item['id'] }}_32.png" />
-                                        {{ $item['type'] }} x{{ $item['quantity'] }}
+                                        {{ $item['type'] }} x{{ $item['quantity'] }}@if(!$item['is_included']) (requested)@endif
                                     </td>
                                     <td>{{ $item['price'] }} isk</td>
                                 </tr>


### PR DESCRIPTION
Append `" (requested)"` to an item when it is requested in a contract instead of given.

**Example:**

<img width="741" height="258" alt="image" src="https://github.com/user-attachments/assets/ffb6096a-d0a9-408e-9dc5-94087bb9507a" />

**First contract:**

<img width="528" height="528" alt="image" src="https://github.com/user-attachments/assets/1b5043cf-4968-46b3-9b6c-03da8a27d6a9" />

**Second contract (note the "Buyer will pay", i.e. items were requested):**

<img width="528" height="476" alt="image" src="https://github.com/user-attachments/assets/7cd72f5f-1a4b-4f5e-ba33-2f49749210bc" />