### PR TITLE
Add roles display below titles for each character

### DIFF
--- a/app/Connectors/EsiConnection.php
+++ b/app/Connectors/EsiConnection.php
@@ -317,6 +317,39 @@ class EsiConnection
     }
 
     /**
+     * Get a character's corporation roles
+     *
+     * @throws ApiException
+     */
+    public function getRoles(): array
+    {
+        $cache_key = "character_roles_$this->char_id";
+
+        if (Cache::has($cache_key)) {
+            return Cache::get($cache_key);
+        }
+
+        $model = new CharacterApi($this->client, $this->config);
+        $roles = $model->getCharactersCharacterIdRolesWithHttpInfo($this->char_id);
+        // The first entry ($roles[0]) is the global set of roles, we ignore the location-specific roles
+        // because they are so rare and would clutter the UI
+        $rawRoles = $roles[0]->getRoles() ?? [];
+
+        if (in_array('Director', $rawRoles)) {
+            // ESI returns every single role for directors (because they implicitly have them), but that
+            // bloats the application page and makes it hard to read so we remove all the extra roles here
+            $out = ['Director'];
+        } else {
+            // ESI returns the role names like 'Station_Manager', but we want it as 'Station Manager'
+            $out = array_map(fn($r) => str_replace('_', ' ', $r), $rawRoles);
+        }
+
+        Cache::add($cache_key, $out, $this->getCacheExpirationTime($roles));
+
+        return $out;
+    }
+
+    /**
      * Get a character's clone information
      *
      * @throws ApiException

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -58,8 +58,9 @@ class ApplicationController extends Controller
             $sp = $esi->getSkillpoints();
             $isk = $esi->getWalletBalance();
             $titles = $esi->getTitles();
+            $roles = $esi->getRoles();
         } catch(Exception) {
-            $sp = $isk = $titles = null;
+            $sp = $isk = $titles = $roles = null;
         }
 
         $tooltips = [];
@@ -82,6 +83,7 @@ class ApplicationController extends Controller
             'sp' => $sp,
             'isk' => $isk,
             'titles' => $titles,
+            'roles' => $roles,
             'state_tooltip' => $tooltips,
             'userApplications' => Application::getUserApplicationsForRecruiter($application->account->main()),
         ]);
@@ -134,8 +136,9 @@ class ApplicationController extends Controller
             $sp = $esi->getSkillpoints();
             $isk = $esi->getWalletBalance();
             $titles = $esi->getTitles();
+            $roles = $esi->getRoles();
         } catch(Exception) {
-            $sp = $isk = $titles = null;
+            $sp = $isk = $titles = $roles = null;
         }
 
         try {
@@ -156,6 +159,7 @@ class ApplicationController extends Controller
             'deleted_characters' => $deleted_chars,
             'added_characters' => $added_chars,
             'titles' => $titles,
+            'roles' => $roles,
             'login_details' => $login_details,
             'userApplications' => Application::getUserApplicationsForRecruiter($char),
         ]);

--- a/resources/views/parts/application/character_header.blade.php
+++ b/resources/views/parts/application/character_header.blade.php
@@ -43,6 +43,11 @@
         Titles: {{ $titles }}
     </div>
 </div>
+<div class="row justify-content-center">
+    <div class="col-xl-6 col-lg-8 col-12 text-center">
+        Roles: {{ implode(', ', $roles) }}
+    </div>
+</div>
 @else
 <div class="row justify-content-center">
     <h4><strong>Invalid ESI Token</strong></h4>


### PR DESCRIPTION
Add display of roles on character pages. Unfortunately this does cost us an extra API call, but I think it's likely worth it.

Testing:

Title-assigned roles:
<img width="667" height="303" alt="image" src="https://github.com/user-attachments/assets/fe377332-a1e1-4e33-a94b-d36e91f0e5bb" />

Directly assigned role:
<img width="371" height="313" alt="image" src="https://github.com/user-attachments/assets/7872b2ed-461b-4dfb-a513-228287e39f77" />

CEO (no separate CEO role):
<img width="491" height="299" alt="image" src="https://github.com/user-attachments/assets/139081a7-5070-4c9e-8e04-60e4fe575e45" />

No Roles:
<img width="624" height="304" alt="image" src="https://github.com/user-attachments/assets/9989bc31-20e3-4383-a93b-ffea7b211026" />