### PR TITLE
Sort corp/group names alphabetically in the UI

### DIFF
--- a/app/Http/Controllers/GroupAdController.php
+++ b/app/Http/Controllers/GroupAdController.php
@@ -81,7 +81,7 @@ class GroupAdController extends Controller
         if (!Auth::user()->hasRole('group admin') && !Auth::user()->hasRoleLike('%manager'))
             return redirect('/')->with('error', 'Unauthorized');
 
-        $ads = AccountRole::getGroupAdsUsercanView();
+        $ads = AccountRole::getGroupAdsUserCanView();
 
         return view('list_ads', [
             'title' => 'Group',
@@ -99,7 +99,7 @@ class GroupAdController extends Controller
         if (!Auth::user()->hasRole('group admin') && !Auth::user()->hasRoleLike('%manager'))
             return redirect('/')->with('error', 'Unauthorized');
 
-        $ads = AccountRole::getGroupAdsUsercanView();
+        $ads = AccountRole::getGroupAdsUserCanView();
 
         return view('list_ads', [
             'title' => 'Group',

--- a/app/Models/Permission/AccountRole.php
+++ b/app/Models/Permission/AccountRole.php
@@ -114,7 +114,12 @@ class AccountRole extends Model
         foreach ($ads as $ad)
             $ad->corp_name = ($ad->corp_id == null) ? null : (new EsiConnection())->getCorporationName($ad->corp_id);
 
-        return $ads->all();
+        $ads = $ads->all();
+        usort($ads, function ($a, $b) {
+            return strnatcasecmp($a->corp_name ?? $a->group_name, $b->corp_name ?? $b->group_name);
+        });
+
+        return $ads;
     }
 
     /**
@@ -168,10 +173,15 @@ class AccountRole extends Model
         }
 
         // array_unique is needed to avoid returning duplicates when the user has both director and recruiter permissions
-        return array_unique($ads, SORT_REGULAR);
+        $ads = array_values(array_unique($ads, SORT_REGULAR));
+        usort($ads, function ($a, $b) {
+            return strnatcasecmp($a->corp_name, $b->corp_name);
+        });
+
+        return $ads;
     }
 
-    public static function getGroupAdsUsercanView()
+    public static function getGroupAdsUserCanView()
     {
         $account_id = Auth::user()->id;
 
@@ -209,7 +219,12 @@ class AccountRole extends Model
         }
 
         // array_unique is needed to avoid returning duplicates when the user has both director and recruiter permissions
-        return array_unique($ads, SORT_REGULAR);
+        $ads = array_values(array_unique($ads, SORT_REGULAR));
+        usort($ads, function ($a, $b) {
+            return strnatcasecmp($a->group_name, $b->group_name);
+        });
+
+        return $ads;
     }
 
     public static function userCanEditAd($type, $id)


### PR DESCRIPTION
Sort group/application names alphabetically in the UI.

Before:
<img width="221" height="132" alt="image" src="https://github.com/user-attachments/assets/7c9b5ee3-602d-46b1-87b8-012a598f4488" />

After:
<img width="172" height="127" alt="image" src="https://github.com/user-attachments/assets/347f6f1c-bc3c-4041-b636-e294c43b4931" />

Changed it in the model itself so the sorting is automatically correct everwhere in the UI, but I can change to doing it in the UI code if we prefer that. Also fixed an obvious typo in the name of `getGroupAdsUsercanView` (capitalized the `c` in `can`).