### PR TITLE
Don't re-fetch mail in getMailDetails, use body we already have

### DIFF
--- a/app/Connectors/EsiConnection.php
+++ b/app/Connectors/EsiConnection.php
@@ -574,7 +574,7 @@ class EsiConnection
         if (Cache::has($mailBodyCacheKey . $mailId)) {
             $mail->contents = Cache::get($mailBodyCacheKey . $mailId);
         } else {
-            $mail->contents = $model->getCharactersCharacterIdMailMailId($this->char_id, $mailId)->getBody();
+            $mail->contents = $mail->getBody();
             Cache::add($mailBodyCacheKey . $mailId, $mail->contents, env('CACHE_TIME', 3264));
         }
 


### PR DESCRIPTION
`getMailDetails` makes two ESI calls to get the same mail, while we can just re-use the object we have from 5 lines up instead.