### PR TITLE
Stop UpdateCoreAccounts from inserting NULLs into the database

### DIFF
--- a/app/Console/Commands/UpdateCoreAccounts.php
+++ b/app/Console/Commands/UpdateCoreAccounts.php
@@ -42,7 +42,9 @@ class UpdateCoreAccounts extends Command
     {
         $users = User::all();
         $accounts = Account::all();
-        $count = 0;
+        $updated = 0;
+        $deleted = 0;
+        $idsToCheck = [];
 
         foreach ($users as $user)
         {
@@ -53,18 +55,36 @@ class UpdateCoreAccounts extends Command
 
         foreach ($users as $user)
         {
-            $user->core_account_id = $mappedIDs[$user->character_id];
-            $user->save();
-            $count++;
+            $coreAccountId = $mappedIDs[$user->character_id];
+
+            if ($coreAccountId === null) {
+                // Neucore returned no player for this character (biomassed/sold/otherwise removed), so delete it.
+                if (Account::where('main_user_id', $user->character_id)->exists()) {
+                    // Skip deleting if the character is a main for an account, as that would break the account.\
+                    echo "Failed to delete character {$user->character_id} because it is the main of an account\n";
+                    continue;
+                }
+                $user->delete();
+                $deleted++;
+            } else {
+                $user->core_account_id = $coreAccountId;
+                $user->save();
+                $updated++;
+            }
         }
 
-        echo "Updated $count characters\n";
+        echo "Updated $updated characters, deleted $deleted characters\n";
         $count = 0;
 
         foreach ($accounts as $account)
         {
-            $user = User::where('account_id', $account->id)->first();
-            $account->core_account_id = $user?->core_account_id;
+            $user = User::where('account_id', $account->id)->whereNotNull('core_account_id')->first();
+            if ($user === null) {
+                // Account has no characters, or all the characters on the account have a NULL core account.
+                continue;
+            }
+
+            $account->core_account_id = $user->core_account_id;
             $account->save();
             $count++;
         }


### PR DESCRIPTION
### Bug

As written, `UpdateCoreAccounts` inserts `NULL`s into the database:

https://github.com/bravecollective/eve-recruitment/blob/5067e2fb6a1a5039f5c6ab285ad17eac44f1e117/app/Console/Commands/UpdateCoreAccounts.php#L54-L59
(Because it confused me, a "user" in JoinUs lingo means an EVE online _character_. While an "account" means a heartbeat.)

What will `$mappedIDs[$user->character_id]` be for a character that has been biomassed? It will be `null`!

`getCharactersAccounts` preloads the array with `null`s, and for a deleted/sold character, Neucore doesn't return it in the API response at all (so the `null` never is overwritten):
https://github.com/bravecollective/eve-recruitment/blob/5067e2fb6a1a5039f5c6ab285ad17eac44f1e117/app/Connectors/CoreConnection.php#L38-L59

Thus, the characters never get cleaned up and haunt the account forever thanks to their `NULL` account ID.

### Fix

This PR makes two major changes to combat that:

- Firstly, in the user loop, it checks if `$coreAccountId` is `null`, and if it is it deletes the User (unless it is the main of an account, as that would break the account).
- Secondly, in the accounts loop, it adds a check to ensure the user we pull to update the account's core account to has a non-null core account (while the above fix should in theory prevent that, there will be existing `NULL`s and another bug could introduce them).

### Testing

```
export UID && docker compose exec -T recruitment_php php /app/artisan update:coreaccounts
Updated 2 characters, deleted 0 characters
Updated 2 accounts
```